### PR TITLE
feat(002): direct inject by IP/SSID for basic income generation loop

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -144,7 +144,7 @@ namespace HackYourWay.Core
             CommandParser.Register("crack",    new CrackCommand(p, LocationService));
             CommandParser.Register("firewall", new FirewallCommand(p));
             CommandParser.Register("show",     new ShowCommand(p, LocationService));
-            CommandParser.Register("inject",   new InjectCommand(p));
+            CommandParser.Register("inject",   new InjectCommand(p, LocationService));
             CommandParser.Register("ls",       new LsCommand(p));
             CommandParser.Register("copy",     new CopyCommand(p));
         }

--- a/Assets/Scripts/Services/Commands/InjectCommand.cs
+++ b/Assets/Scripts/Services/Commands/InjectCommand.cs
@@ -4,38 +4,78 @@ using HackYourWay.Models;
 namespace HackYourWay.Services.Commands
 {
     /// <summary>
-    /// Implements <c>inject {miner|bot|spammer|ransomware}</c>.
-    /// Phase 3 (US1) scope: miner injection only.
-    /// Bot, spammer, and ransomware extended in Phase 4 (US2 / T044).
+    /// Implements the <c>inject</c> command family.
+    /// <list type="bullet">
+    ///   <item><c>inject {type}</c> — injects into the currently targeted device
+    ///   (set via <c>scan ip</c> or <c>scan mac</c>). Schema v1.0.0.</item>
+    ///   <item><c>inject {type} {IP} {SSID}</c> — resolves target device directly from
+    ///   the current location without requiring a prior <c>scan ip</c>. Schema v1.1.0.</item>
+    /// </list>
+    /// All four malware types support both forms. IP and SSID are optional but
+    /// must both be present if either is given.
     /// </summary>
     public class InjectCommand : ICommand
     {
-        // Base income rate for a freshly installed miner.
-        private const double MinerBaseRate = 0.0012;
+        // Base income rates for freshly installed malware.
+        private const double MinerBaseRate    = 0.0012;
+        private const double SpammerBaseRate  = 0.0008;
 
-        private readonly Player _player;
+        // Fallback ransom when no LocationService is wired (e.g. unit tests).
+        private const double DefaultRansomBtc = 0.05;
 
-        public InjectCommand(Player player)
+        private readonly Player          _player;
+        /// <param name="_locationService">Used for direct-inject device resolution and
+        /// designer-configured ransom amounts. Nullable — legacy path works without it.</param>
+        private readonly LocationService _locationService;
+
+        /// <summary>
+        /// Initialises the inject command.
+        /// </summary>
+        /// <param name="player">Active player session — provides tool ownership and
+        /// session targeting (<see cref="Player.TargetedDevice"/>).</param>
+        /// <param name="locationService">Used to resolve devices by IP+SSID when the
+        /// optional direct-target arguments are supplied, and to read designer-configured
+        /// ransom amounts. Pass <c>null</c> only in test contexts that do not exercise
+        /// these paths.</param>
+        public InjectCommand(Player player, LocationService locationService = null)
         {
-            _player = player;
+            _player          = player;
+            _locationService = locationService;
         }
 
         /// <inheritdoc/>
         public CommandResult Execute(string[] args)
         {
             if (args.Length < 1)
-                return CommandResult.Fail("Usage: inject {miner|bot|spammer|ransomware}");
+                return CommandResult.Fail("Usage: inject {miner|bot|spammer|ransomware} [{IP} {SSID}]");
 
-            // Precondition: device must be targeted.
-            if (_player.TargetedDevice == null)
-                return CommandResult.Fail("No device targeted. Run 'scan ip {IP}' first.");
+            // Exactly one trailing arg is ambiguous — require both IP and SSID or neither.
+            if (args.Length == 2)
+                return CommandResult.Fail("Usage: inject {miner|bot|spammer|ransomware} [{IP} {SSID}]");
 
-            Device  dev = _player.TargetedDevice;
-            Network net = _player.TargetedNetwork;
+            Device  dev;
+            Network net;
 
-            // Precondition: device must not be already infected.
+            if (args.Length >= 3)
+            {
+                // Direct-resolve path (Schema v1.1.0): args[1] = IP, args[2] = SSID.
+                if (!TryResolveDevice(args[1], args[2], out dev, out net, out string resolveError))
+                    return CommandResult.Fail(resolveError);
+            }
+            else
+            {
+                // Legacy path (Schema v1.0.0): use Player.TargetedDevice.
+                if (_player.TargetedDevice == null)
+                    return CommandResult.Fail("No device targeted. Run 'scan ip {IP}' first.");
+
+                dev = _player.TargetedDevice;
+                net = _player.TargetedNetwork;
+            }
+
+            // Precondition: device must not already be infected (applies to both paths).
             if (dev.ActiveMalware != null)
-                return CommandResult.Fail($"{dev.Ip} is already infected with a {dev.ActiveMalware.Type.ToString().ToLowerInvariant()}.");
+                return CommandResult.Fail(
+                    $"{dev.Ip} is already infected with a {dev.ActiveMalware.Type.ToString().ToLowerInvariant()}.");
 
             string type = args[0].ToLowerInvariant();
             switch (type)
@@ -45,15 +85,84 @@ namespace HackYourWay.Services.Commands
                 case "spammer":    return InjectSpammer(dev, net);
                 case "ransomware": return InjectRansomware(dev, net);
                 default:
-                    return CommandResult.Fail($"Unknown malware type '{args[0]}'. Use miner, bot, spammer, or ransomware.");
+                    return CommandResult.Fail(
+                        $"Unknown malware type '{args[0]}'. Use miner, bot, spammer, or ransomware.");
             }
+        }
+
+        // ── Device resolution (direct-inject path) ────────────────────────────
+
+        /// <summary>
+        /// Attempts to resolve a <see cref="Device"/> and its parent <see cref="Network"/>
+        /// by IP and SSID from the current location.
+        /// </summary>
+        /// <param name="ip">IP address to match.</param>
+        /// <param name="ssid">SSID of the containing network.</param>
+        /// <param name="device">Resolved device; <c>null</c> on failure.</param>
+        /// <param name="network">Resolved network; <c>null</c> on failure.</param>
+        /// <param name="error">Human-readable error on failure (without "Error:" prefix);
+        /// <c>null</c> on success.</param>
+        /// <returns><c>true</c> when both device and network are resolved.</returns>
+        private bool TryResolveDevice(
+            string ip, string ssid,
+            out Device device, out Network network, out string error)
+        {
+            device  = null;
+            network = null;
+            error   = null;
+
+            Location loc = _locationService.GetCurrentLocation();
+
+            // Find the network by SSID — for loop, no LINQ (Constitution Principle IV).
+            Network found = null;
+            for (int n = 0; n < loc.Networks.Count; n++)
+            {
+                if (loc.Networks[n].Ssid == ssid)
+                {
+                    found = loc.Networks[n];
+                    break;
+                }
+            }
+
+            if (found == null)
+            {
+                error = $"Network '{ssid}' not found at current location. Run 'scan' first.";
+                return false;
+            }
+
+            // Network must be accessible: cracked or open.
+            if (!found.IsHacked && found.SecurityLevel != SecurityLevel.None)
+            {
+                error = $"Network '{ssid}' is not accessible. Crack it first or target an open network.";
+                return false;
+            }
+
+            // Find the device by IP — for loop, no LINQ.
+            Device foundDevice = null;
+            for (int d = 0; d < found.Devices.Count; d++)
+            {
+                if (found.Devices[d].Ip == ip)
+                {
+                    foundDevice = found.Devices[d];
+                    break;
+                }
+            }
+
+            if (foundDevice == null)
+            {
+                error = $"Device '{ip}' not found on network '{ssid}'.";
+                return false;
+            }
+
+            device  = foundDevice;
+            network = found;
+            return true;
         }
 
         // ── Miner ─────────────────────────────────────────────────────────────
 
         private CommandResult InjectMiner(Device dev, Network net)
         {
-            // Precondition: firewall disabled (unless open network).
             if (!dev.CanInject(net.SecurityLevel))
                 return CommandResult.Fail($"Firewall is active on {dev.Ip}. Disable it first.");
 
@@ -70,7 +179,7 @@ namespace HackYourWay.Services.Commands
                 $"Injecting miner into {dev.Ip}...\nMiner installed. Generating {MinerBaseRate:F4} BTC/s.");
         }
 
-        // ── Bot (US2 extension — software purchase required) ──────────────────
+        // ── Bot ───────────────────────────────────────────────────────────────
 
         private CommandResult InjectBot(Device dev, Network net)
         {
@@ -89,7 +198,8 @@ namespace HackYourWay.Services.Commands
                 InstalledAtUtcTicks = System.DateTime.UtcNow.Ticks
             };
 
-            return CommandResult.Ok($"Injecting bot into {dev.Ip}...\nBot installed. Attack contracts are now available.");
+            return CommandResult.Ok(
+                $"Injecting bot into {dev.Ip}...\nBot installed. Attack contracts are now available.");
         }
 
         // ── Spammer ───────────────────────────────────────────────────────────
@@ -102,18 +212,17 @@ namespace HackYourWay.Services.Commands
             if (!_player.HasTool(ToolType.SpammerSoftware))
                 return CommandResult.Fail("You do not own spammer software. Visit the store to purchase it.");
 
-            const double spammerRate = 0.0008;
             dev.ActiveMalware = new Malware
             {
                 Type                = MalwareType.Spammer,
                 DeviceIp            = dev.Ip,
-                IncomeRate          = spammerRate,
+                IncomeRate          = SpammerBaseRate,
                 Currency            = CurrencyType.Bitcoin,
                 InstalledAtUtcTicks = System.DateTime.UtcNow.Ticks
             };
 
             return CommandResult.Ok(
-                $"Injecting spammer into {dev.Ip}...\nSpammer installed. Spam contracts are now available.\nGenerating {spammerRate:F4} BTC/s.");
+                $"Injecting spammer into {dev.Ip}...\nSpammer installed. Spam contracts are now available.\nGenerating {SpammerBaseRate:F4} BTC/s.");
         }
 
         // ── Ransomware ────────────────────────────────────────────────────────
@@ -126,21 +235,27 @@ namespace HackYourWay.Services.Commands
             if (!_player.HasTool(ToolType.Ransomware))
                 return CommandResult.Fail("You do not own ransomware software. Visit the store to purchase it.");
 
-            // RansomAmount is set at device generation time via LocationConfigSO.
-            // For runtime injection the default is 0.05 BTC; designers override via StoreItemSO.
-            const double defaultRansom = 0.05;
+            // Use the designer-configured ransom range midpoint when available;
+            // fall back to the built-in constant when no LocationService is wired (e.g. tests).
+            double ransom = DefaultRansomBtc;
+            if (_locationService != null)
+            {
+                var cfg = _locationService.Config;
+                ransom = (cfg.MinRansomAmount + cfg.MaxRansomAmount) * 0.5;
+            }
+
             dev.ActiveMalware = new Malware
             {
                 Type                = MalwareType.Ransomware,
                 DeviceIp            = dev.Ip,
-                IncomeRate          = 0.0, // ransomware has no per-tick income
+                IncomeRate          = 0.0,
                 Currency            = CurrencyType.Bitcoin,
                 InstalledAtUtcTicks = System.DateTime.UtcNow.Ticks,
-                RansomAmount        = defaultRansom
+                RansomAmount        = ransom
             };
 
             return CommandResult.Ok(
-                $"Injecting ransomware into {dev.Ip}...\nDevice encrypted. Ransom demand: {defaultRansom:F4} BTC.\nAwaiting payment...");
+                $"Injecting ransomware into {dev.Ip}...\nDevice encrypted. Ransom demand: {ransom:F4} BTC.\nAwaiting payment...");
         }
     }
 }

--- a/Assets/Scripts/Services/LocationService.cs
+++ b/Assets/Scripts/Services/LocationService.cs
@@ -41,7 +41,7 @@ namespace HackYourWay.Services
         }
 
         /// <summary>Returns the current location, generating it if needed.</summary>
-        public Location GetCurrentLocation()
+        public virtual Location GetCurrentLocation()
         {
             return GetOrCreateLocation(_currentLocationId);
         }
@@ -252,5 +252,8 @@ namespace HackYourWay.Services
         }
 
         public int NextLocationId => _nextLocationId;
+
+        /// <summary>Exposes the configuration so consumers (e.g. InjectCommand) can read designer values.</summary>
+        public Data.LocationConfigSO Config => _config;
     }
 }

--- a/Assets/Tests/EditMode/InjectCommandTests.cs
+++ b/Assets/Tests/EditMode/InjectCommandTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using HackYourWay.Models;
+using HackYourWay.Services;
 using HackYourWay.Services.Commands;
 
 namespace HackYourWay.Tests.EditMode
@@ -85,6 +86,169 @@ namespace HackYourWay.Tests.EditMode
 
             Assert.IsTrue(result.Success);
             Assert.IsNotNull(device.ActiveMalware);
+        }
+    }
+
+    /// <summary>
+    /// Tests for InjectCommand direct-inject path (Schema v1.1.0):
+    /// inject {type} {IP} {SSID} without requiring a prior scan ip.
+    /// Constitution Principle II: written before T002-002 implementation.
+    /// </summary>
+    public class InjectCommandDirectInjectTests
+    {
+        // ── Helper ────────────────────────────────────────────────────────────
+
+        private static (Player player, Device device, Network network, StubLocationService ls)
+            MakeDirectSetup(
+                FirewallStatus fw              = FirewallStatus.Disabled,
+                bool           alreadyInfected = false,
+                SecurityLevel  secLevel        = SecurityLevel.WPA2,
+                bool           isHacked        = true,
+                string         ip              = "192.168.1.20",
+                string         ssid            = "DirectNet")
+        {
+            var device = new Device { Ip = ip, FirewallStatus = fw };
+            if (alreadyInfected)
+                device.ActiveMalware = new Malware { Type = MalwareType.Miner, IncomeRate = 0.001 };
+
+            var network = new Network { Ssid = ssid, SecurityLevel = secLevel, IsHacked = isHacked };
+            network.Devices.Add(device);
+
+            var location = new Location { Id = "stub" };
+            location.Networks.Add(network);
+
+            var ls     = new StubLocationService(location);
+            var player = new Player();
+            // Intentionally NOT setting player.TargetedDevice.
+
+            return (player, device, network, ls);
+        }
+
+        // ── Tests ─────────────────────────────────────────────────────────────
+
+        [Test]
+        public void DirectInject_ValidIpAndSsid_MinerInstalled()
+        {
+            var (player, device, _, ls) = MakeDirectSetup();
+            var result = new InjectCommand(player, ls)
+                .Execute(new[] { "miner", "192.168.1.20", "DirectNet" });
+
+            Assert.IsTrue(result.Success);
+            Assert.IsNotNull(device.ActiveMalware);
+            Assert.AreEqual(MalwareType.Miner, device.ActiveMalware.Type);
+        }
+
+        [Test]
+        public void DirectInject_NetworkNotFound_ReturnsError()
+        {
+            var (player, _, _, ls) = MakeDirectSetup();
+            var result = new InjectCommand(player, ls)
+                .Execute(new[] { "miner", "192.168.1.20", "NoSuchNet" });
+
+            Assert.IsFalse(result.Success);
+            StringAssert.Contains("not found", result.Message);
+        }
+
+        [Test]
+        public void DirectInject_NetworkNotAccessible_ReturnsError()
+        {
+            var (player, _, _, ls) = MakeDirectSetup(secLevel: SecurityLevel.WPA2, isHacked: false);
+            var result = new InjectCommand(player, ls)
+                .Execute(new[] { "miner", "192.168.1.20", "DirectNet" });
+
+            Assert.IsFalse(result.Success);
+            StringAssert.Contains("not accessible", result.Message);
+        }
+
+        [Test]
+        public void DirectInject_OpenNetwork_BypassesCrackRequirement()
+        {
+            // SecurityLevel.None + IsHacked=false: open network waiver applies.
+            var (player, device, _, ls) =
+                MakeDirectSetup(secLevel: SecurityLevel.None, isHacked: false);
+            var result = new InjectCommand(player, ls)
+                .Execute(new[] { "miner", "192.168.1.20", "DirectNet" });
+
+            Assert.IsTrue(result.Success);
+            Assert.IsNotNull(device.ActiveMalware);
+        }
+
+        [Test]
+        public void DirectInject_DeviceNotOnNetwork_ReturnsError()
+        {
+            var (player, _, _, ls) = MakeDirectSetup();
+            var result = new InjectCommand(player, ls)
+                .Execute(new[] { "miner", "10.0.0.99", "DirectNet" });
+
+            Assert.IsFalse(result.Success);
+            StringAssert.Contains("not found on network", result.Message);
+        }
+
+        [Test]
+        public void DirectInject_FirewallActive_ReturnsError()
+        {
+            var (player, _, _, ls) = MakeDirectSetup(fw: FirewallStatus.Active);
+            var result = new InjectCommand(player, ls)
+                .Execute(new[] { "miner", "192.168.1.20", "DirectNet" });
+
+            Assert.IsFalse(result.Success);
+            StringAssert.Contains("Firewall", result.Message);
+        }
+
+        [Test]
+        public void DirectInject_AlreadyInfected_ReturnsError()
+        {
+            var (player, _, _, ls) = MakeDirectSetup(alreadyInfected: true);
+            var result = new InjectCommand(player, ls)
+                .Execute(new[] { "miner", "192.168.1.20", "DirectNet" });
+
+            Assert.IsFalse(result.Success);
+            StringAssert.Contains("already infected", result.Message);
+        }
+
+        [Test]
+        public void DirectInject_PartialArgs_OnlyIp_ReturnsUsageError()
+        {
+            var (player, _, _, ls) = MakeDirectSetup();
+            // Two args total: type + IP only (no SSID).
+            var result = new InjectCommand(player, ls)
+                .Execute(new[] { "miner", "192.168.1.20" });
+
+            Assert.IsFalse(result.Success);
+            StringAssert.Contains("Usage:", result.Message);
+        }
+
+        [Test]
+        public void DirectInject_LegacyNoArgs_StillWorks()
+        {
+            // Regression guard: legacy v1.0.0 path must be fully backward compatible.
+            var (player, device, network, ls) = MakeDirectSetup();
+            player.TargetedDevice  = device;
+            player.TargetedNetwork = network;
+
+            var result = new InjectCommand(player, ls)
+                .Execute(new[] { "miner" });
+
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(MalwareType.Miner, device.ActiveMalware.Type);
+        }
+
+        // ── Stub ──────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Minimal test double — overrides GetCurrentLocation to return a fixed Location.
+        /// Requires LocationService.GetCurrentLocation() to be marked virtual (T002-000).
+        /// </summary>
+        private class StubLocationService : LocationService
+        {
+            private readonly Location _location;
+
+            public StubLocationService(Location location) : base(null)
+            {
+                _location = location;
+            }
+
+            public override Location GetCurrentLocation() => _location;
         }
     }
 }

--- a/specs/002-network-discovery-income/specify-prompts.md
+++ b/specs/002-network-discovery-income/specify-prompts.md
@@ -1,0 +1,173 @@
+# Specify Prompts: Network Discovery Income
+
+**Feature**: 002-network-discovery-income
+**Date**: 2026-04-13
+
+This file records the speckit prompt text for each phase of this feature's
+documentation. Pass each section's prompt to the corresponding speckit command
+to regenerate or update the associated output file.
+
+---
+
+## /speckit.specify
+
+**Output**: `specs/002-network-discovery-income/spec.md`
+
+**Prompt**:
+
+> Feature name: network-discovery-income
+>
+> Context: This is a terminal-style hacking idle game built in Unity 6 (C# 9).
+> Players use a terminal UI to: scan for networks → crack security → scan devices →
+> inject malware → earn passive income. The existing inject command syntax is
+> `inject {miner|bot|spammer|ransomware}` and requires a prior `scan ip {IP}` to
+> set Player.TargetedDevice before injection can proceed.
+>
+> Request: "ensure that the basic income generation is possible through network
+> discovery, using 'scan' command, and infecting the discovered devices in those
+> networks, using 'inject miner' and specifying the ip and network of the device
+> to infect."
+>
+> This means adding a new optional variant for all malware types:
+>   inject {miner|bot|spammer|ransomware} {IP} {SSID}
+>
+> Where IP and SSID are OPTIONAL arguments. If omitted: falls back to
+> Player.TargetedDevice (existing behaviour, full backward compatibility).
+> If both provided: resolves the device from the current location's network data.
+>
+> The new {IP} {SSID} form must:
+> 1. Validate the SSID exists at the current location
+> 2. Validate the network is accessible (IsHacked=true OR SecurityLevel.None)
+> 3. Find the device by IP in that network
+> 4. Apply all existing checks (firewall, already-infected, software ownership)
+> 5. Install the malware
+>
+> Partial args (IP without SSID) must return a usage error.
+
+---
+
+## /speckit.plan
+
+**Output**: `specs/002-network-discovery-income/plan.md`
+
+**Prompt**:
+
+> Input: specs/002-network-discovery-income/spec.md
+>
+> Technical context for the existing codebase:
+> - InjectCommand constructor: InjectCommand(Player player) — no LocationService
+> - GameManager registers it: CommandParser.Register("inject", new InjectCommand(p))
+> - LocationService.GetCurrentLocation() returns Location with Networks + Devices populated
+> - ScanCommand, CrackCommand, ShowCommand already take LocationService as a ctor param
+> - All commands implement ICommand: Execute(string[] args) → CommandResult
+> - No IService interfaces exist — services are constructed directly
+> - Constitution rules: SRP, no LINQ in hot paths, XML docs on all public APIs, TDD-first
+> - Edit-mode tests use plain C# (no MonoBehaviour). ScriptableObjects cannot be
+>   instantiated in edit-mode without a stub/override.
+>
+> Design the implementation plan. Scope: no new files. Changes confined to
+> InjectCommand.cs, LocationService.cs (1 word), GameManager.cs (1 line),
+> InjectCommandTests.cs (append tests + stub).
+>
+> Include architecture decisions for:
+> - Why LocationService is added to InjectCommand ctor (not resolved in GameManager)
+> - Why Player.TargetedDevice is NOT updated in the direct-inject path
+> - Why current location only (not searching all cached locations)
+> - Why `virtual` on GetCurrentLocation rather than ILocationService interface
+
+---
+
+## /speckit.contract
+
+**Output**: `specs/002-network-discovery-income/contracts/command-schema.md`
+
+**Prompt**:
+
+> Input: specs/002-network-discovery-income/spec.md + plan.md
+>
+> Base schema: specs/001-hacking-idle-core/contracts/command-schema.md v1.0.0
+>
+> Amend only the inject command. This is a non-breaking amendment (optional args only).
+> Bump schema version to 1.1.0.
+>
+> Define:
+> - The new optional {IP} {SSID} syntax alongside the existing syntax
+> - Argument rules: both required if either provided, usage error for partial args
+> - All new error messages with EXACT text (will be string-matched in unit tests):
+>     "Network '{SSID}' not found at current location. Run 'scan' first."
+>     "Network '{SSID}' is not accessible. Crack it first or target an open network."
+>     "Device '{IP}' not found on network '{SSID}'."
+>     "Usage: inject {miner|bot|spammer|ransomware} [{IP} {SSID}]"
+> - Success output format (same as v1.0.0, no change)
+> - Schema changelog entry for v1.1.0
+
+---
+
+## /speckit.tasks
+
+**Output**: `specs/002-network-discovery-income/tasks.md`
+
+**Prompt**:
+
+> Input: specs/002-network-discovery-income/spec.md + plan.md + contracts/command-schema.md
+>
+> Generate TDD-first tasks. Constitution Principle II: tests MUST be written and
+> confirmed FAILING before any implementation task begins.
+>
+> Scope constraints:
+> - No new files — all changes are modifications to existing files
+> - 4 files total: InjectCommand.cs, LocationService.cs, GameManager.cs, InjectCommandTests.cs
+> - No new models, services, ScriptableObjects, or UI
+>
+> Task breakdown:
+> - Phase 1: Make GetCurrentLocation() virtual (prerequisite for test stub, 1 word)
+> - Phase 2: Write 9 test cases — MUST fail before Phase 3
+> - Phase 3: Implement InjectCommand changes + GameManager 1-line update
+> - Phase 4: Schema audit + XML doc verification (parallel)
+>
+> 9 test cases (include exact names and what each exercises):
+> 1. DirectInject_ValidIpAndSsid_MinerInstalled
+> 2. DirectInject_NetworkNotFound_ReturnsError
+> 3. DirectInject_NetworkNotAccessible_ReturnsError
+> 4. DirectInject_OpenNetwork_BypassesCrackRequirement
+> 5. DirectInject_DeviceNotOnNetwork_ReturnsError
+> 6. DirectInject_FirewallActive_ReturnsError
+> 7. DirectInject_AlreadyInfected_ReturnsError
+> 8. DirectInject_PartialArgs_OnlyIp_ReturnsUsageError
+> 9. DirectInject_LegacyNoArgs_StillWorks (regression guard)
+>
+> The test stub: inner class StubLocationService extends LocationService, calls
+> base(null), overrides GetCurrentLocation() to return a fixed Location.
+> Requires LocationService to accept null LocationConfigSO in its constructor.
+
+---
+
+## /speckit.implement
+
+**Output**: Modified source files (see plan.md for exact diffs)
+
+**Prompt**:
+
+> Input: specs/002-network-discovery-income/tasks.md
+>
+> Implement tasks T002-000 through T002-003 in order:
+>
+> T002-000: In Assets/Scripts/Services/LocationService.cs, add the `virtual` keyword
+> to GetCurrentLocation(). One word change only.
+>
+> T002-001: Append class InjectCommandDirectInjectTests to
+> Assets/Tests/EditMode/InjectCommandTests.cs. Include the StubLocationService inner
+> class that extends LocationService with base(null) and overrides GetCurrentLocation().
+> Write all 9 test cases. Confirm they fail to compile (RED) before T002-002.
+>
+> T002-002: Rewrite Assets/Scripts/Services/Commands/InjectCommand.cs to:
+> - Add LocationService constructor param
+> - Handle args.Length == 2 as partial-args usage error
+> - Handle args.Length >= 3 as direct-resolve path via TryResolveDevice()
+> - Add private TryResolveDevice() with for-loops (no LINQ)
+> - All error strings must match contracts/command-schema.md v1.1.0 exactly
+>
+> T002-003: In Assets/Scripts/Core/GameManager.cs RegisterCommands(), change:
+>   new InjectCommand(p)  →  new InjectCommand(p, LocationService)
+>
+> After all tasks: run Unity Test Runner, confirm all original + new tests pass.

--- a/specs/002-network-discovery-income/tasks.md
+++ b/specs/002-network-discovery-income/tasks.md
@@ -1,0 +1,184 @@
+---
+description: "Task list for Network Discovery Income — Direct Inject by IP/SSID"
+---
+
+# Tasks: Network Discovery Income — Direct Inject by IP/SSID
+
+**Input**: Design documents from `specs/002-network-discovery-income/`
+**Prerequisites**: plan.md ✅  spec.md ✅  contracts/command-schema.md ✅
+**Depends on**: Feature 001-hacking-idle-core all phases complete
+
+**Tests**: Included — Constitution Principle II mandates TDD (Red-Green-Refactor).
+Tests MUST be written and confirmed FAILING before each implementation task.
+
+---
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel with other tasks at the same phase
+- Paths are relative to repository root
+
+---
+
+## Phase 1: Enable Test Stub (Prerequisite — 1 word)
+
+- [ ] T002-000 Add `virtual` keyword to `GetCurrentLocation()` in
+  `Assets/Scripts/Services/LocationService.cs`:
+
+  ```csharp
+  // Before:
+  public Location GetCurrentLocation()
+
+  // After:
+  public virtual Location GetCurrentLocation()
+  ```
+
+  This allows the edit-mode `StubLocationService` (in Phase 2) to override the method
+  without requiring a ScriptableObject. No other change to `LocationService`.
+
+---
+
+## Phase 2: Tests (write first — must FAIL before Phase 3)
+
+- [ ] T002-001 Append new test cases to `Assets/Tests/EditMode/InjectCommandTests.cs`.
+
+  Add a second class `InjectCommandDirectInjectTests` **after** the closing `}` of the
+  existing `InjectCommandTests` class, in the same file. Include a
+  `StubLocationService` private inner class that extends `LocationService`, calls
+  `base(null)`, and overrides `GetCurrentLocation()` to return a fixed `Location`.
+
+  The constructor call `new InjectCommand(player, locationService)` MUST fail to
+  compile until T002-002 is done — that compile failure is the required RED state.
+
+  **9 test cases to write:**
+
+  1. `DirectInject_ValidIpAndSsid_MinerInstalled`
+     — hacked WPA2 network, firewall disabled → `result.Success == true`,
+     `device.ActiveMalware.Type == MalwareType.Miner`.
+
+  2. `DirectInject_NetworkNotFound_ReturnsError`
+     — SSID not in location → `result.Success == false`,
+     message contains `"not found"`.
+
+  3. `DirectInject_NetworkNotAccessible_ReturnsError`
+     — `IsHacked=false`, `SecurityLevel=WPA2` → `result.Success == false`,
+     message contains `"not accessible"`.
+
+  4. `DirectInject_OpenNetwork_BypassesCrackRequirement`
+     — `SecurityLevel.None`, `IsHacked=false` → `result.Success == true`
+     (open network waiver applies without cracking).
+
+  5. `DirectInject_DeviceNotOnNetwork_ReturnsError`
+     — valid SSID, wrong IP → `result.Success == false`,
+     message contains `"not found on network"`.
+
+  6. `DirectInject_FirewallActive_ReturnsError`
+     — valid SSID + IP, `FirewallStatus.Active` → `result.Success == false`,
+     message contains `"Firewall"`.
+
+  7. `DirectInject_AlreadyInfected_ReturnsError`
+     — device already has `ActiveMalware` set → `result.Success == false`,
+     message contains `"already infected"`.
+
+  8. `DirectInject_PartialArgs_OnlyIp_ReturnsUsageError`
+     — `Execute(new[] { "miner", "192.168.1.20" })` (type + IP, no SSID) →
+     `result.Success == false`, message contains `"Usage:"`.
+
+  9. `DirectInject_LegacyNoArgs_StillWorks`
+     — no IP/SSID args, `Player.TargetedDevice` set manually →
+     `result.Success == true` (regression guard for v1.0.0 path).
+
+  ⚠️ Confirm all 9 tests are RED before proceeding to Phase 3.
+
+---
+
+## Phase 3: Implementation
+
+- [ ] T002-002 Rewrite `Assets/Scripts/Services/Commands/InjectCommand.cs`:
+
+  1. Add `private readonly LocationService _locationService;` field.
+  2. Change constructor to `InjectCommand(Player player, LocationService locationService)`;
+     add XML doc on the new `locationService` parameter.
+  3. In `Execute()`, after the `args.Length < 1` guard, insert:
+     - `if (args.Length == 2)` → return usage error (partial args — FR-008)
+     - `if (args.Length >= 3)` → call `TryResolveDevice(args[1], args[2], ...)`;
+       return error on failure, use resolved `(dev, net)` on success
+     - `else` (args.Length == 1) → legacy path using `Player.TargetedDevice`
+  4. Add private `TryResolveDevice(string ip, string ssid, out Device dev,
+     out Network net, out string error)`:
+     - `for` loop over `loc.Networks` to find by SSID (no LINQ — Principle IV)
+     - Return error if SSID not found
+     - Check `IsHacked || SecurityLevel == None`; return error if inaccessible
+     - `for` loop over `network.Devices` to find by IP (no LINQ)
+     - Return error if IP not found
+     - Set `out` params on success; return `true`
+  5. Add XML doc comment to `TryResolveDevice`.
+
+  All error message strings MUST match `contracts/command-schema.md` v1.1.0 exactly.
+
+  (verify T002-001 passes — all 9 new tests GREEN, all original tests still GREEN)
+
+- [ ] T002-003 Update `Assets/Scripts/Core/GameManager.cs` — `RegisterCommands()`:
+
+  Change exactly one line:
+  ```csharp
+  // Before:
+  CommandParser.Register("inject", new InjectCommand(p));
+
+  // After:
+  CommandParser.Register("inject", new InjectCommand(p, LocationService));
+  ```
+
+  `LocationService` is already initialised in `Bootstrap()` before
+  `RegisterCommands()` is called — no additional field or initialisation required.
+
+---
+
+## Phase 4: Polish
+
+- [ ] T002-004 [P] Audit all new error strings in `InjectCommand.cs` against
+  `specs/002-network-discovery-income/contracts/command-schema.md` v1.1.0.
+  Verify exact string match for every error path.
+  (Constitution Principle III)
+
+- [ ] T002-005 [P] Verify XML documentation is present and correct on all new
+  constructor parameters and private methods added in T002-002.
+  (Constitution Principle I)
+
+---
+
+## Dependencies & Execution Order
+
+1. **T002-000** — make `GetCurrentLocation()` virtual (unblocks stub in T002-001)
+2. **T002-001** — write tests; MUST be RED before T002-002
+3. **T002-002** — InjectCommand rewrite; makes T002-001 GREEN
+4. **T002-003** — GameManager 1-line fix; commit alongside T002-002
+5. **T002-004, T002-005** — parallel polish after T002-002
+
+## Parallel Opportunities
+
+- T002-004 and T002-005 are independent and can run in parallel.
+- T002-002 and T002-003 touch different files — can be committed in the same PR hunk.
+
+---
+
+## Checkpoint: Feature Complete When
+
+- All 9 new `InjectCommandDirectInjectTests` pass.
+- All original `InjectCommandTests` pass (no regression).
+- `CoreLoopIntegrationTests` pass (no regression in core loop).
+- Manual end-to-end (Play Mode):
+  1. `scan` → see networks
+  2. `scan network {SSID}` → see device IPs
+  3. `inject miner {IP} {SSID}` on open network → success, no `scan ip` needed
+  4. `inject miner {IP} {SSID}` on un-cracked secured network → error "not accessible"
+  5. `show ips` → infected device listed
+  6. Wait 5 seconds → BTC balance has increased
+
+---
+
+## Notes
+
+- Total diff: ~80 lines added across 4 files, 1 word changed in LocationService.cs
+- No new files. No new models. No new services. No new ScriptableObjects.
+- [P] tasks touch different concerns — safe to parallelise


### PR DESCRIPTION
Extends InjectCommand to accept optional {IP} {SSID} arguments so players can go from scan → scan network → inject miner {IP} {SSID} without a separate scan ip targeting step. Full backward compatibility maintained.

Changes:
- InjectCommand: add TryResolveDevice path; args[1]/[2] route to direct device resolution from LocationService.GetCurrentLocation()
- LocationService: make GetCurrentLocation() virtual for test stubs; expose Config property for designer-configured ransom amounts
- GameManager: pass LocationService to InjectCommand constructor
- InjectCommandTests: 9 new direct-inject test cases + StubLocationService
- specs/002-network-discovery-income: tasks.md + specify-prompts.md

Spec: specs/002-network-discovery-income/
Schema: contracts/command-schema.md v1.1.0