### PR TITLE
feat(004): add help command with per-verb usage detail

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,18 @@
       "Bash(git commit -m ' *)",
       "Bash(git push *)",
       "Bash(gh pr *)",
-      "PowerShell(gh pr list --head feature/003-terminal-behaviour --repo flesteaf/FirstIdleAttempt)"
+      "PowerShell(gh pr list --head feature/003-terminal-behaviour --repo flesteaf/FirstIdleAttempt)",
+      "Bash(git checkout *)",
+      "Bash(git add *)",
+      "PowerShell($env:PATH)",
+      "PowerShell(Get-ChildItem \"C:\\\\Program Files\\\\GitHub CLI\\\\gh.exe\" -ErrorAction SilentlyContinue; Get-ChildItem \"$env:LOCALAPPDATA\\\\Programs\\\\GitHub CLI\\\\gh.exe\" -ErrorAction SilentlyContinue; Get-ChildItem \"C:\\\\ProgramData\\\\chocolatey\\\\bin\\\\gh.exe\" -ErrorAction SilentlyContinue; Get-ChildItem \"$env:USERPROFILE\\\\scoop\\\\shims\\\\gh.exe\" -ErrorAction SilentlyContinue)",
+      "PowerShell(cmd /c \"dir `\"C:\\\\Program Files\\\\PowerShell`\" /b\")",
+      "PowerShell(cmd /c \"dir `\"C:\\\\Program Files\\\\PowerShell\\\\7`\" /b\")",
+      "PowerShell(cmd /c \"wmic product where `\"name like '%PowerShell%'`\" get name,version,installlocation 2>nul\")",
+      "PowerShell(winget list --id Microsoft.PowerShell)",
+      "PowerShell(cmd /c \"where pwsh\")",
+      "PowerShell(cmd /c \"dir `\"C:\\\\Program Files\\\\PowerShell`\" /s /b\")",
+      "PowerShell(cmd /c \"C:\\\\Users\\\\flest\\\\AppData\\\\Local\\\\Microsoft\\\\WindowsApps\\\\pwsh.exe\" --version 2>&1)"
     ]
   }
 }

--- a/Assets/Prefabs/Terminal.prefab
+++ b/Assets/Prefabs/Terminal.prefab
@@ -366,8 +366,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4281479730
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+    rgba: 2156175748
+  m_fontColor: {r: 0.51723033, g: 0.6301887, b: 0.51723033, a: 0.5}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -1356,8 +1356,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+    rgba: 4292473561
+  m_fontColor: {r: 0.8509804, g: 0.9490196, b: 0.8509804, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -1508,8 +1508,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 2150773298
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 0.5}
+    rgba: 2156175748
+  m_fontColor: {r: 0.51723033, g: 0.6301887, b: 0.51723033, a: 0.5}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:

--- a/Assets/Scenes/TerminalScene.unity
+++ b/Assets/Scenes/TerminalScene.unity
@@ -548,6 +548,10 @@ PrefabInstance:
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5414684463330297073, guid: b0b3b6e84330d334ca99bcb4af455f31, type: 3}
+      propertyPath: _nodeId
+      value: NODE_77
+      objectReference: {fileID: 0}
     - target: {fileID: 6116289065756365240, guid: b0b3b6e84330d334ca99bcb4af455f31, type: 3}
       propertyPath: m_Pivot.x
       value: 0

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -147,6 +147,8 @@ namespace HackYourWay.Core
             CommandParser.Register("inject",   new InjectCommand(p, LocationService));
             CommandParser.Register("ls",       new LsCommand(p));
             CommandParser.Register("copy",     new CopyCommand(p));
+            // Registered last so GetRegisteredVerbs() returns the complete list.
+            CommandParser.Register("help",     new HelpCommand(CommandParser));
         }
 
         // ── Save ─────────────────────────────────────────────────────────────

--- a/Assets/Scripts/Services/Commands/HelpCommand.cs
+++ b/Assets/Scripts/Services/Commands/HelpCommand.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.Text;
+using HackYourWay.Interfaces;
+
+namespace HackYourWay.Services.Commands
+{
+    /// <summary>
+    /// Implements the <c>help</c> command.
+    /// With no arguments: lists all registered command verbs with a one-line description.
+    /// With a verb argument (e.g. <c>help scan</c>): shows detailed usage for that command.
+    /// </summary>
+    public class HelpCommand : ICommand
+    {
+        // ── Static usage catalogue ────────────────────────────────────────────
+
+        /// <summary>
+        /// One-line descriptions for every registered verb.
+        /// Keep in sync with <see cref="GameManager.RegisterCommands"/>.
+        /// </summary>
+        private static readonly Dictionary<string, string> s_usage =
+            new Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase)
+            {
+                { "help",     "help [command]         — show this list or detail for a command" },
+                { "scan",     "scan                   — discover networks at current location" },
+                { "crack",    "crack <ssid>           — break into a WEP/WPA network" },
+                { "firewall", "firewall <on|off>      — toggle your personal firewall" },
+                { "show",     "show <networks|ips>    — display known networks or infected devices" },
+                { "inject",   "inject <ip> <type>     — deploy malware onto a compromised device" },
+                { "ls",       "ls                     — list items in your current directory" },
+                { "copy",     "copy <src> <dst>       — copy a file between paths" },
+            };
+
+        // ── Dependencies ──────────────────────────────────────────────────────
+
+        private readonly CommandParser _parser;
+        private readonly StringBuilder _sb = new StringBuilder(512);
+
+        public HelpCommand(CommandParser parser)
+        {
+            _parser = parser;
+        }
+
+        // ── ICommand ──────────────────────────────────────────────────────────
+
+        /// <inheritdoc/>
+        public CommandResult Execute(string[] args)
+        {
+            if (args.Length > 0)
+                return DetailFor(args[0]);
+
+            return ListAll();
+        }
+
+        // ── Internal ──────────────────────────────────────────────────────────
+
+        /// <summary>Lists every registered verb with its one-line description.</summary>
+        private CommandResult ListAll()
+        {
+            _sb.Clear();
+            _sb.AppendLine("Available commands:");
+            _sb.AppendLine();
+
+            IReadOnlyList<string> verbs = _parser.GetRegisteredVerbs();
+            for (int i = 0; i < verbs.Count; i++)
+            {
+                string verb = verbs[i];
+                string line = s_usage.TryGetValue(verb, out string desc)
+                    ? $"  {desc}"
+                    : $"  {verb}";
+                _sb.AppendLine(line);
+            }
+
+            return CommandResult.Ok(_sb.ToString());
+        }
+
+        /// <summary>Shows the usage line for a specific verb.</summary>
+        private CommandResult DetailFor(string verb)
+        {
+            if (s_usage.TryGetValue(verb, out string desc))
+                return CommandResult.Ok(desc);
+
+            return CommandResult.Fail($"No help entry for '{verb}'.");
+        }
+    }
+}

--- a/Assets/Scripts/Services/Commands/HelpCommand.cs.meta
+++ b/Assets/Scripts/Services/Commands/HelpCommand.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 479488aa1f57cdb48b6e08e10bd2909f

--- a/Assets/TextMesh Pro/Resources/Fonts & Materials/LiberationSans SDF - Fallback.asset
+++ b/Assets/TextMesh Pro/Resources/Fonts & Materials/LiberationSans SDF - Fallback.asset
@@ -2,20 +2,24 @@
 %TAG !u! tag:unity3d.com,2011:
 --- !u!21 &2180264
 Material:
-  serializedVersion: 6
+  serializedVersion: 8
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: LiberationSans SDF Material
   m_Shader: {fileID: 4800000, guid: fe393ace9b354375a9cb14cdbbc28be4, type: 3}
-  m_ShaderKeywords: 
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
   m_LightmapFlags: 1
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -67,6 +71,7 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    m_Ints: []
     m_Floats:
     - _Ambient: 0.5
     - _Bevel: 0.5
@@ -148,6 +153,8 @@ Material:
     - _ReflectOutlineColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
     - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.5}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -161,11 +168,6 @@ MonoBehaviour:
   m_Name: LiberationSans SDF - Fallback
   m_EditorClassIdentifier: 
   m_Version: 1.1.0
-  m_Material: {fileID: 2180264}
-  m_SourceFontFileGUID: e3265ab4bf004d28a9537516768c1c75
-  m_SourceFontFile: {fileID: 12800000, guid: e3265ab4bf004d28a9537516768c1c75, type: 3}
-  m_AtlasPopulationMode: 1
-  InternalDynamicOS: 0
   m_FaceInfo:
     m_FaceIndex: 0
     m_FamilyName: Liberation Sans
@@ -188,57 +190,8 @@ MonoBehaviour:
     m_StrikethroughOffset: 18
     m_StrikethroughThickness: 6.298828
     m_TabWidth: 24
-  m_GlyphTable: []
-  m_CharacterTable: []
-  m_AtlasTextures:
-  - {fileID: 28268798066460806}
-  m_AtlasTextureIndex: 0
-  m_IsMultiAtlasTexturesEnabled: 1
-  m_ClearDynamicDataOnBuild: 1
-  m_UsedGlyphRects: []
-  m_FreeGlyphRects:
-  - m_X: 0
-    m_Y: 0
-    m_Width: 511
-    m_Height: 511
-  m_fontInfo:
-    Name: Liberation Sans
-    PointSize: 86
-    Scale: 1
-    CharacterCount: 250
-    LineHeight: 98.90625
-    Baseline: 0
-    Ascender: 77.84375
-    CapHeight: 59.1875
-    Descender: -18.21875
-    CenterLine: 0
-    SuperscriptOffset: 77.84375
-    SubscriptOffset: -12.261719
-    SubSize: 0.5
-    Underline: -12.261719
-    UnderlineThickness: 6.298828
-    strikethrough: 23.675
-    strikethroughThickness: 0
-    TabWidth: 239.0625
-    Padding: 9
-    AtlasWidth: 1024
-    AtlasHeight: 1024
-  atlas: {fileID: 0}
-  m_AtlasWidth: 512
-  m_AtlasHeight: 512
-  m_AtlasPadding: 9
-  m_AtlasRenderMode: 4169
-  m_glyphInfoList: []
-  m_KerningTable:
-    kerningPairs: []
-  m_FontFeatureTable:
-    m_MultipleSubstitutionRecords: []
-    m_LigatureSubstitutionRecords: []
-    m_GlyphPairAdjustmentRecords: []
-    m_MarkToBaseAdjustmentRecords: []
-    m_MarkToMarkAdjustmentRecords: []
-  fallbackFontAssets: []
-  m_FallbackFontAssetTable: []
+  m_Material: {fileID: 2180264}
+  m_SourceFontFileGUID: e3265ab4bf004d28a9537516768c1c75
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: e3265ab4bf004d28a9537516768c1c75
@@ -258,6 +211,36 @@ MonoBehaviour:
     fontStyleModifier: 0
     renderMode: 4169
     includeFontFeatures: 1
+  m_SourceFontFile: {fileID: 12800000, guid: e3265ab4bf004d28a9537516768c1c75, type: 3}
+  m_SourceFontFilePath: 
+  m_AtlasPopulationMode: 1
+  InternalDynamicOS: 0
+  m_GlyphTable: []
+  m_CharacterTable: []
+  m_AtlasTextures:
+  - {fileID: 28268798066460806}
+  m_AtlasTextureIndex: 0
+  m_IsMultiAtlasTexturesEnabled: 1
+  m_GetFontFeatures: 1
+  m_ClearDynamicDataOnBuild: 1
+  m_AtlasWidth: 512
+  m_AtlasHeight: 512
+  m_AtlasPadding: 9
+  m_AtlasRenderMode: 4169
+  m_UsedGlyphRects: []
+  m_FreeGlyphRects:
+  - m_X: 0
+    m_Y: 0
+    m_Width: 511
+    m_Height: 511
+  m_FontFeatureTable:
+    m_MultipleSubstitutionRecords: []
+    m_LigatureSubstitutionRecords: []
+    m_GlyphPairAdjustmentRecords: []
+    m_MarkToBaseAdjustmentRecords: []
+    m_MarkToMarkAdjustmentRecords: []
+  m_ShouldReimportFontFeatures: 0
+  m_FallbackFontAssetTable: []
   m_FontWeightTable:
   - regularTypeface: {fileID: 0}
     italicTypeface: {fileID: 0}
@@ -306,6 +289,33 @@ MonoBehaviour:
   boldSpacing: 7
   italicStyle: 35
   tabSize: 10
+  m_fontInfo:
+    Name: Liberation Sans
+    PointSize: 86
+    Scale: 1
+    CharacterCount: 250
+    LineHeight: 98.90625
+    Baseline: 0
+    Ascender: 77.84375
+    CapHeight: 59.1875
+    Descender: -18.21875
+    CenterLine: 0
+    SuperscriptOffset: 77.84375
+    SubscriptOffset: -12.261719
+    SubSize: 0.5
+    Underline: -12.261719
+    UnderlineThickness: 6.298828
+    strikethrough: 23.675
+    strikethroughThickness: 0
+    TabWidth: 239.0625
+    Padding: 9
+    AtlasWidth: 1024
+    AtlasHeight: 1024
+  m_glyphInfoList: []
+  m_KerningTable:
+    kerningPairs: []
+  fallbackFontAssets: []
+  atlas: {fileID: 0}
 --- !u!28 &28268798066460806
 Texture2D:
   m_ObjectHideFlags: 0
@@ -316,17 +326,21 @@ Texture2D:
   m_ImageContentsHash:
     serializedVersion: 2
     Hash: 00000000000000000000000000000000
-  m_ForcedFallbackFormat: 4
-  m_DownscaleFallback: 0
-  serializedVersion: 2
-  m_Width: 0
-  m_Height: 0
-  m_CompleteImageSize: 0
+  m_IsAlphaChannelOptional: 0
+  serializedVersion: 4
+  m_Width: 1
+  m_Height: 1
+  m_CompleteImageSize: 1
+  m_MipsStripped: 0
   m_TextureFormat: 1
   m_MipCount: 1
   m_IsReadable: 1
+  m_IsPreProcessed: 0
+  m_IgnoreMipmapLimit: 0
+  m_MipmapLimitGroupName: 
   m_StreamingMipmaps: 0
   m_StreamingMipmapsPriority: 0
+  m_VTOnly: 0
   m_AlphaIsTransparency: 0
   m_ImageCount: 1
   m_TextureDimension: 2
@@ -340,9 +354,11 @@ Texture2D:
     m_WrapW: 0
   m_LightmapFormat: 0
   m_ColorSpace: 0
-  image data: 0
-  _typelessdata: 
+  m_PlatformBlob: 
+  image data: 1
+  _typelessdata: 00
   m_StreamData:
+    serializedVersion: 2
     offset: 0
     size: 0
     path: 


### PR DESCRIPTION
## Summary
- `help` with no args lists all registered commands with one-line usage descriptions
- `help <verb>` (e.g. `help crack`) shows detail for a specific command
- `help` is registered last in `RegisterCommands()` so `GetRegisteredVerbs()` always returns the full list
- No changes to `ICommand` interface — descriptions live in a static dictionary inside `HelpCommand`
- Tab-autocomplete picks up `help` automatically (it's in the parser registry)

## Fixes
Resolves "unknown command" error when typing `help` in the terminal on `develop`.

## Test plan
- [ ] Type `help` → full command list appears
- [ ] Type `help scan` → single-line usage for `scan`
- [ ] Type `help xyz` → error: No help entry for 'xyz'
- [ ] Press Tab on empty input → `help` appears in the autocomplete list

🤖 Generated with [Claude Code](https://claude.com/claude-code)